### PR TITLE
Compare primary keys on {table}.{column} naming + performance improve…

### DIFF
--- a/sql-queries/pfkd-v2.sql
+++ b/sql-queries/pfkd-v2.sql
@@ -40,28 +40,26 @@ SELECT
 FROM
     information_schema.COLUMNS cl
     INNER JOIN information_schema.COLUMNS cr ON cl.table_name <> cr.table_name
+    AND cl.table_schema = cr.table_schema
     AND cl.data_type = cr.data_type
-AND cl.column_name IN (
-    SELECT
-        DISTINCT column_name
-    FROM
-        information_schema.statistics
-    WHERE
-        table_schema = DATABASE()
-        AND index_name = 'primary'
+    AND CONCAT(cl.table_name, '.', cl.column_name) IN (
+        SELECT DISTINCT CONCAT(table_name, '.', column_name)
+        FROM
+            information_schema.statistics
+        WHERE
+            table_schema = DATABASE()
+            AND index_name = 'primary'
     )
-AND cr.column_name NOT IN (
-    SELECT
-        DISTINCT column_name
-    FROM
-        information_schema.statistics
-    WHERE
-        table_schema = DATABASE()
-        AND index_name = 'primary'
+    AND CONCAT(cr.table_name, '.', cr.column_name) NOT IN (
+        SELECT DISTINCT CONCAT(table_name, '.', column_name)
+        FROM
+            information_schema.statistics
+        WHERE
+            table_schema = DATABASE()
+            AND index_name = 'primary'
     )
 WHERE
     cl.table_schema = DATABASE()
-    AND cr.table_schema = DATABASE()
     AND cl.data_type NOT IN ( 'datetime', 'date', 'timestamp', 'enum', 'money', 'text', 'longtext', 'longblob', 'blob', 'decimal' )
 ORDER BY
-    cr.table_schema;
+    cl.table_schema;


### PR DESCRIPTION
Hej brode @kimmeyera.

Denne PR introducerer en simpel ændring der successfuldt sammenligner og filtrerer venstre-side PK col navne som {table}.{column} i stedet for bare {column}. Det vil sige at man nu kan køre PfkD ordentligt på skemaer hvor FK cols hedder det samme som PK cols. 

Dette fungerer også efter hensigten i mine tests - f.eks. kan "Employees" skemaet bruges til test, hvis du stadig har det liggende i din localhost. Dog skal man lige være opmærksom på en vigtig begrænsing ift. det skema (og løsningen her), at FK cols der samtidig er en del af en composite key altså stadig ikke understøttes: Dette er fordi vi filtrerer dem fra på højre side hvis de har index type "primary". Man kan måske på sigt kigge på en regel omkring at bruge `SEQ_IN_INDEX` fra `STATISTICS` metadata tabellen for at vurdere om det er del af en composite eller ej, men nok ude af scope for opgaven her.

På forhånd tak for review, gode! 

closes #2 